### PR TITLE
make firefox-zip depend on firefox instead of chrome

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ chrome: ${CHROME} ${CHROME}/app.js ${CHROME}/manifest.json ${CHROME}/background.
 chrome-zip: chrome
 	cd ${CHROME} && rm -f ${CHROME_ZIP} && zip -o -r ${CHROME_ZIP} .
 
-firefox-zip: chrome
+firefox-zip: firefox
 	cd ${FIREFOX} && rm -f ${FIREFOX_ZIP} && zip -o -r ${FIREFOX_ZIP} .
 
 ${CHROME}:


### PR DESCRIPTION
It looks like _firefox-zip_ is supposed to depend on _firefox_, not _chrome_. `make all` still works because it builds _firefox_ first anyway, but `make firefox-zip` fails.
